### PR TITLE
Fix HTTP list param 

### DIFF
--- a/request.go
+++ b/request.go
@@ -28,21 +28,19 @@ func (r *request) setParam(key string, value interface{}) *request {
 		r.query = url.Values{}
 	}
 
-	if reflect.TypeOf(value).Kind() == reflect.Slice {
-		v, err := json.Marshal(value)
-		if err == nil {
-			value = string(v)
+	if val := reflect.ValueOf(value); val.Kind() == reflect.Slice {
+		for i := 0; i < val.Len(); i++ {
+			v := fmt.Sprintf("%v", val.Index(i).Interface())
+			if i == 0 {
+				r.query.Set(key, fmt.Sprintf("%v", v))
+			} else {
+				r.query.Add(key, fmt.Sprintf("%v", v))
+			}
 		}
+		return r
 	}
 
 	r.query.Set(key, fmt.Sprintf("%v", value))
-	return r
-}
-
-func (r *request) setParamList(baseParam string, params ...interface{}) *request {
-	for index, value := range params {
-		r.setParam(fmt.Sprintf("%s[%d]", baseParam, index), value)
-	}
 	return r
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -1,0 +1,79 @@
+package listmonk
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_request_setParam(t *testing.T) {
+	type args struct {
+		key   string
+		value interface{}
+	}
+	tests := []struct {
+		name  string
+		query url.Values
+		args  args
+		want  url.Values
+	}{
+		{
+			name:  "set string",
+			query: url.Values{},
+			args: args{
+				key:   "foo",
+				value: "bar",
+			},
+			want: url.Values{
+				"foo": []string{"bar"},
+			},
+		},
+		{
+			name:  "set slice",
+			query: url.Values{},
+			args: args{
+				key:   "foo",
+				value: []string{"bar1", "bar2"},
+			},
+			want: url.Values{
+				"foo": []string{"bar1", "bar2"},
+			},
+		},
+		{
+			name: "replace string",
+			query: url.Values{
+				"foo": []string{"old"},
+			},
+			args: args{
+				key:   "foo",
+				value: "bar",
+			},
+			want: url.Values{
+				"foo": []string{"bar"},
+			},
+		},
+		{
+			name: "replace slice",
+			query: url.Values{
+				"foo": []string{"old1", "old2"},
+			},
+			args: args{
+				key:   "foo",
+				value: []string{"bar1", "bar2"},
+			},
+			want: url.Values{
+				"foo": []string{"bar1", "bar2"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &request{
+				query: tt.query,
+			}
+			r = r.setParam(tt.args.key, tt.args.value)
+			assert.Equal(t, tt.want, r.query)
+		})
+	}
+}

--- a/subscriber_service.go
+++ b/subscriber_service.go
@@ -1,12 +1,11 @@
 package listmonk
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
-
-	"context"
 )
 
 type SubscriberList struct {
@@ -76,7 +75,7 @@ func (s *GetSubscribersService) Do(ctx context.Context, opts ...requestOption) (
 		r.setParam("query", *s.query)
 	}
 	if len(s.listIds) > 0 {
-		r.setParamList("list_id", s.listIds)
+		r.setParam("list_id", s.listIds)
 	}
 
 	bytes, err := s.c.callAPI(ctx, r, opts...)
@@ -509,7 +508,7 @@ func (s *DeleteSubscribersService) Do(ctx context.Context, opts ...requestOption
 		endpoint: "/subscribers",
 	}
 
-	r.setParamList("id", s.ids)
+	r.setParam("id", s.ids)
 
 	bytes, err := s.c.callAPI(ctx, r, opts...)
 


### PR DESCRIPTION
It should be `?list_id=1&list_id=2`, not `?list_id[0]=[1 2]` nor `?list_id[0]=1&list_id[1]=2`.

See https://listmonk.app/docs/apis/subscribers/#get-apisubscribers and https://listmonk.app/docs/apis/subscribers/#delete-apisubscribers