### PR TITLE
Properly convert list-like queryargs.

### DIFF
--- a/request.go
+++ b/request.go
@@ -39,9 +39,9 @@ func (r *request) setParam(key string, value interface{}) *request {
 	return r
 }
 
-func (r *request) setParamList(baseParam string, params ...interface{}) *request {
-	for index, value := range params {
-		r.setParam(fmt.Sprintf("%s[%d]", baseParam, index), value)
+func (r *request) setParamList(baseParam string, params []uint) *request {
+	for _, value := range params {
+		r.setParam(baseParam, fmt.Sprintf("%d", value))
 	}
 	return r
 }


### PR DESCRIPTION
Without this change setting the ListId value to [1, 2] yields queryargs like

list_id[0]=[1,2]

What it should be, according to the documentation is

list_id=1&list_id=2

This change does that by forcibly converting each value to a string directly rather than leveraging the JSON marshalling of setParam.